### PR TITLE
Fix project builds on macOS

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -148,7 +148,7 @@ $(BUILD)/assets/%.1bpp: assets/%.png
 # Special hack to place a ret instruction at the end of the GSINIT section.
 # This has to be linked last, as that ensures that this fragment is at the end of the "GSINIT" section.
 $(BUILD)/gsinit.end.o:
-	@/bin/echo -e 'SECTION FRAGMENT "GSINIT", ROMX, BANK[1]\n  ret' | rgbasm - -o $@
+	@printf 'SECTION FRAGMENT "GSINIT", ROMX, BANK[1]\n  ret' | rgbasm - -o $@
 
 clean:
 	@rm -rf $(BUILD) $(PROJECT_NAME).$(ROM_EXTENSION) $(PROJECT_NAME).map $(PROJECT_NAME).sym


### PR DESCRIPTION
The `-e` flag for `echo` is not supported on macOS, by switching to `printf` this should hopefully be a bit more cross-platform. Tested on macOS and Ubuntu (WSL).

Wasn't sure if you were accepting PRs at the moment, but I am itching to start using this project 😄