### PR TITLE
Add system type detection

### DIFF
--- a/inc/sdk/system.h
+++ b/inc/sdk/system.h
@@ -1,0 +1,14 @@
+#ifndef GBSDK_SYSTEM_H
+#define GBSDK_SYSTEM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CPU_DMG 0x01 // Dot Matrix Game
+#define CPU_CGB 0x11 // Color GameBoy
+#define CPU_MGB 0xFF // Mini GameBoy (Pocket GameBoy)
+
+extern uint8_t cpu_type; // DMG, CGB or MGB
+extern bool system_is_gba; // Is the system a GBA or a CGB? (Only valid if cpu_type == CPU_CGB)
+
+#endif//GBSDK_SYSTEM_H

--- a/src/entry.asm
+++ b/src/entry.asm
@@ -1,5 +1,11 @@
 include "sdk/hardware.inc"
 
+SECTION "gbsdk_systeminfo_ram", WRAM0
+_cpu_type::
+wCpuType:: ds 1
+_system_is_gba::
+wSystemIsGba:: ds 1
+
 
 SECTION "Header", ROM0[$100]
     di
@@ -8,7 +14,10 @@ SECTION "Header", ROM0[$100]
 
 SECTION "Init", ROMX, BANK[1]
 startRom:
-    ld   sp, $E000
+    ld   sp, $E000 ; Set stack pointer to the top of WRAM
+    ld [wCpuType], a ; Detect system type based on initial register state
+    ld a, b
+    ld [wSystemIsGba], a
     call ___globalsInitCode ; init C globals
     call _main
     db   $DD ; lock up if main returns ($DD is an invalid opcode)


### PR DESCRIPTION
Necessary for games that want to run on both base and color Game Boys and use the GBC's extra features.