### PR TITLE
More robust SDCC 4.2.0 checking

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -1,9 +1,9 @@
 .PHONY: all clean
 
 # SDCC renamed the `gbz80` arch to `sm83` in 4.2.0
-SDCC_VERSION := $(shell sdcc --version | head -n 1 | awk '{print $$4}')
 ARCH := gbz80
-ifeq ($(SDCC_VERSION), 4.2.0)
+SDCC_VERSTRING := $(shell sdcc --version)
+ifeq ($(findstring sm83,$(SDCC_VERSTRING)),sm83)
 	ARCH := sm83
 endif
 


### PR DESCRIPTION
sdcc --version lists the supported architectures, so we just need to check if it's sm83 or gbz80 in that list. Easier than checking version numbers.