### PR TITLE
Fix for new SDCC calling convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project has a few goals:
 
 To use this, you need to have installed:
 
-* sdcc (version 4.1.0)
+* sdcc (version 4.2.0)
 * rgbds (version 0.5.1)
 * python (version 3.6 or newer)
 * A strong will, and a bit of crazy.

--- a/inc/sdk/sgb.h
+++ b/inc/sdk/sgb.h
@@ -33,7 +33,7 @@
 
 #define SGB_HEADER(command, length) ((uint8_t)(((command) << 3) | (length)))
 
-void sgb_send(const uint8_t* packet);
+void sgb_send(const uint8_t* packet) __preserves_regs(b);
 #endif
 
 #endif

--- a/inc/sdk/video.h
+++ b/inc/sdk/video.h
@@ -9,8 +9,8 @@
 void lcd_off(void) __preserves_regs(b, c, d, e, h, l);
 
 //Copy to VRAM with STAT checks, so these function are safe to write to VRAM at any time.
-void vram_memcpy(uint16_t dst, void* src, uint16_t size) __preserves_regs(b, c);
-void vram_memset(uint16_t dst, uint8_t value, uint16_t size) __preserves_regs(b, c);
+void vram_memcpy(uint16_t dst, void* src, uint16_t size);
+void vram_memset(uint16_t dst, uint8_t value, uint16_t size) __preserves_regs(b);
 inline void vram_set(uint16_t dst, uint8_t value) {
     while(rSTAT & STAT_BUSY) {}
     *((uint8_t*)dst) = value;

--- a/src/sgb.asm
+++ b/src/sgb.asm
@@ -7,10 +7,13 @@ _sgb_send::
     ; SGB RESET pulse
     xor  a
     ldh  [rP1], a
-    ld   h, d ; hl=pointer to data to send
-    ld   l, e ; done here for delay reasons
+    push hl ; for delay only
     cpl
     ldh  [rP1], a
+    pop  hl ; for delay only
+    
+    ld   h, d ; hl=pointer to data to send
+    ld   l, e
     ld   e, 16 ; amount of bytes to send
 
 .byteLoop:

--- a/src/sgb.asm
+++ b/src/sgb.asm
@@ -4,17 +4,13 @@ IF SGB
 
 SECTION "gbsdk_sgb_functions", ROM0
 _sgb_send::
-    pop  de
-    pop  hl
-    ; hl=pointer to data to send
-
     ; SGB RESET pulse
     xor  a
     ldh  [rP1], a
-    push hl ; done here for delay reasons
+    ld   h, d ; hl=pointer to data to send
+    ld   l, e ; done here for delay reasons
     cpl
     ldh  [rP1], a
-    push de ; done here for delay reasons
     ld   e, 16 ; amount of bytes to send
 
 .byteLoop:

--- a/src/video.asm
+++ b/src/video.asm
@@ -10,86 +10,89 @@ _lcd_off::
     ret
 
 _vram_memcpy::
-    ld   hl, sp + 7
-    ld   a, [hl-]
-    ld   d, a
-    ld   a, [hl-]
-    ld   e, a
-    or   a, d
-    ret  z
-    ; size -> de
+    ; src is in bc, dst is in de, size is on the stack
 
-    push bc
-     ld   a, [hl-]
-     ld   b, a
-     ld   a, [hl-]
-     ld   c, a
-     ld   a, [hl-]
-     ld   l, [hl]
-     ld   h, a
-     ; src -> bc, dst -> hl, size -> de
-     inc  d
-     inc  e
-     jr   .start
+    ld   hl, sp + 2
+    ld   a, [hl+]
+    ld   h, [hl]
+    ld   l, a
+    or   a, h
+    ret  z
+    ; size -> hl
+
+    ld   a, h
+    ld   h, d
+    ld   d, a
+
+    ld   a, l
+    ld   l, e
+    ld   e, a
+    ; swap hl and de, so now:
+    ; src -> bc, dst -> hl, size -> de
+    inc  d
+    inc  e
+    jr   .start
 
 .copy_loop:
-     ldh  a, [rSTAT]
-     and  a, STATF_BUSY
-     jr   nz, .copy_loop
-     ld   a, [bc]
-     ld   [hl+], a
-     inc  bc
+    ldh  a, [rSTAT]
+    and  a, STATF_BUSY
+    jr   nz, .copy_loop
+    ld   a, [bc]
+    ld   [hl+], a
+    inc  bc
 .start:
-     dec  e
-     jr   nz, .copy_loop
-     dec  d
-     jr   nz, .copy_loop
+    dec  e
+    jr   nz, .copy_loop
+    dec  d
+    jr   nz, .copy_loop
 
-    pop bc
     ret
 
 _vram_memset::
-    ld   hl, sp + 6
-    ld   a, [hl-]
-    ld   d, a
-    ld   a, [hl-]
-    ld   e, a
-    or   a, d
+    ; value is in a, dst is in de, size is on the stack
+    ld   c, a
+    ; value -> c
+
+    ld   hl, sp + 2
+    ld   a, [hl+]
+    ld   h, [hl]
+    ld   l, a
+    or   a, h
     ret  z
-    ; size -> de
-    push bc
-     ld   a, [hl-]
-     ld   c, a
-     ld   a, [hl-]
-     ld   l, [hl]
-     ld   h, a
-     ; value -> c, dst -> hl, size -> de
-     inc  d
-     inc  e
-     jr   .start
+    ; size -> hl
+
+    ld   a, h
+    ld   h, d
+    ld   d, a
+
+    ld   a, l
+    ld   l, e
+    ld   e, a
+    ; swap hl and de, so now:
+    ; value -> c, dst -> hl, size -> de
+    inc  d
+    inc  e
+    jr   .start
 
 .copy_loop:
-     ldh  a, [rSTAT]
-     and  a, STATF_BUSY
-     jr   nz, .copy_loop
-     ld   a, c
-     ld   [hl+], a
+    ldh  a, [rSTAT]
+    and  a, STATF_BUSY
+    jr   nz, .copy_loop
+    ld   a, c
+    ld   [hl+], a
 .start:
-     dec  e
-     jr   nz, .copy_loop
-     dec  d
-     jr   nz, .copy_loop
+    dec  e
+    jr   nz, .copy_loop
+    dec  d
+    jr   nz, .copy_loop
 
-    pop bc
     ret
 
 IF CGB
 
 _cgb_background_palette::
-    pop  de
-    pop  hl
-    push hl
-    push de
+    ld   h, d
+    ld   l, e
     ld   a, BCPSF_AUTOINC
     ldh  [rBCPS], a
     ld   e, 8*4*2
@@ -100,10 +103,8 @@ _cgb_background_palette::
     ret
 
 _cgb_object_palette::
-    pop  de
-    pop  hl
-    push hl
-    push de
+    ld   h, d
+    ld   l, e
     ld   a, OCPSF_AUTOINC
     ldh  [rOCPS], a
     ld   e, 8*4*2


### PR DESCRIPTION
Apparently SDCC 4.2.0 changed the default calling convention, which broke several GBSDK lib functions. I've fixed the offending functions here. This change will break compatibility with older SDCC versions, so 4.2.0 will need to be the new minimum.